### PR TITLE
security: replace unsalted SHA-256 with bcrypt for web UI password

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22
 require (
 	github.com/emersion/go-imap/v2 v2.0.0-beta.5
 	github.com/emersion/go-message v0.18.2
+	golang.org/x/crypto v0.23.0
 	golang.org/x/term v0.20.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/webui.go
+++ b/webui.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"context"
-	"crypto/sha256"
 	"crypto/subtle"
-	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -14,12 +12,13 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/crypto/bcrypt"
 	"gopkg.in/yaml.v3"
 )
 
 // webui serves a small single-page dashboard to inspect state, browse the
 // audit log, edit the config, and trigger ad-hoc runs. Single-user,
-// HTTP-basic-auth gated by a SHA-256 hash of a configured password.
+// HTTP-basic-auth gated by a bcrypt hash of a configured password.
 
 func cmdWebUI(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("webui", flag.ContinueOnError)
@@ -47,7 +46,11 @@ func cmdWebUI(ctx context.Context, args []string) error {
 		return fmt.Errorf("set a password via --pass or SMARTMAIL_WEB_PASS — refusing to serve an unauthenticated UI")
 	}
 
-	srv := &webServer{cfg: cfg, cfgPath: cfgPath, user: u, passHash: sha(p)}
+	hash, err := bcrypt.GenerateFromPassword([]byte(p), bcrypt.DefaultCost)
+	if err != nil {
+		return fmt.Errorf("hashing password: %w", err)
+	}
+	srv := &webServer{cfg: cfg, cfgPath: cfgPath, user: u, passHash: hash}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", srv.auth(srv.index))
 	mux.HandleFunc("/api/status", srv.auth(srv.apiStatus))
@@ -80,7 +83,7 @@ type webServer struct {
 	cfg      *Config
 	cfgPath  string
 	user     string
-	passHash string
+	passHash []byte
 
 	mu       sync.Mutex
 	running  bool
@@ -88,17 +91,12 @@ type webServer struct {
 	lastStat ProcessStats
 }
 
-func sha(s string) string {
-	h := sha256.Sum256([]byte(s))
-	return hex.EncodeToString(h[:])
-}
-
 func (w *webServer) auth(next http.HandlerFunc) http.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request) {
 		u, p, ok := r.BasicAuth()
-		if !ok ||
-			subtle.ConstantTimeCompare([]byte(u), []byte(w.user)) != 1 ||
-			subtle.ConstantTimeCompare([]byte(sha(p)), []byte(w.passHash)) != 1 {
+		userMatch := ok && subtle.ConstantTimeCompare([]byte(u), []byte(w.user)) == 1
+		passMatch := userMatch && bcrypt.CompareHashAndPassword(w.passHash, []byte(p)) == nil
+		if !passMatch {
 			rw.Header().Set("WWW-Authenticate", `Basic realm="smartmail"`)
 			http.Error(rw, "unauthorized", http.StatusUnauthorized)
 			return


### PR DESCRIPTION
Fixes #2.

## What

Replaces the bare `sha256.Sum256` password hash in `webui.go` with `bcrypt.GenerateFromPassword` (cost 10) and `bcrypt.CompareHashAndPassword`.

## Why

Unsalted SHA-256 provides no brute-force resistance beyond the password's own entropy. A rainbow table or dictionary attack can recover common or short passwords instantly if the in-memory hash is ever extracted. bcrypt adds a random salt and is deliberately slow.

The username check retains `subtle.ConstantTimeCompare` to avoid user-enumeration timing leaks.

## Notes

- `golang.org/x/crypto v0.23.0` added to `go.mod`. Run `go mod tidy` to regenerate `go.sum` before merging.
- No behaviour change for valid credentials; only the internal hash function differs.
- Mitigating factors noted in #2 still apply (loopback-only by default, hash never written to disk).