### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+    open-pull-requests-limit: 5
+    groups:
+      patch-and-minor:
+        update-types: ["patch", "minor"]
+    labels: ["dependencies"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"


### PR DESCRIPTION
This is an automated maintenance task.

Adds `.github/dependabot.yml` to enable weekly grouped dependency update PRs with a 5-PR cap per ecosystem. Detected ecosystem: **gomod** (root `go.mod`).

The `golang.org/x/crypto`, `golang.org/x/term`, and `golang.org/x/sys` packages in `go.mod` are currently pinned to May 2024 releases (v0.23.x / v0.20.x). Dependabot will surface patch and minor updates automatically once this is merged.

See [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference) for customization options.